### PR TITLE
Allow api_key to be rendered from a jinja2 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ inventory = ./inventory/tailscale.yaml
 ```yaml
 plugin: freeformz.ansible.tailscale # must be freeformz.ansible.tailscale
 ansible_host: ipv4                  # ipv4, ipv6, dns, or host_name - Depends on how you referred to the hosts before this
-api_key: "<a tailscale api key>"    # a Tailscale API Key - https://tailscale.com/kb/1101/api/
+api_key: "<a tailscale api key>"    # static Tailscale API Key or Jinja2 template - https://tailscale.com/kb/1101/api/
 tailnet: freeformz.github           # The name of your tailnet - What you see at the top left of https://login.tailscale.com/admin/machines
 ```
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: freeformz
 name: ansible
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.3.0
+version: 0.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/tailscale.py
+++ b/plugins/inventory/tailscale.py
@@ -27,7 +27,7 @@ DOCUMENTATION = """
             required: True
             choices: ['freeformz.ansible.tailscale']
         api_key:
-            description: API key to use.
+            description: API key to use. Can also be a jinja2 template to get the key from another source, like the token endpoint with OAuth credentials.
             type: string
             required: true
         tailnet:
@@ -78,7 +78,7 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 plugin: freeformz.ansible.tailscale
-api_key: "tskey-abunchofcharacters"
+api_key: '{{ lookup("pipe", "./scripts/get-tailscale-api-token") }}'
 tailnet: my.tailnet
 include_self: false
 ansible_host: host_name
@@ -282,7 +282,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         super(InventoryModule, self).__init__()
 
     def get_inventory(self):
-        api_key = self.get_option("api_key")
+        api_key = self.templar.template(self.get_option("api_key"))
         tailnet = self.get_option("tailnet")
         tailscale = TailscaleAPI(
             api_key, tailnet, remove_tag_prefix=self.get_option("strip_tag")


### PR DESCRIPTION
Many other inventory plugins, such as the AWS and Digital Ocean ones, allow using Jinja2 templates in some fields, especially anything with a secret, to avoid committing the secret to the inventory YAML files.

This adds it just for the `api_key` option, which also provides a simple option for #3.

For example we use this bash script to get a temporary API token with OAuth creds and the `/token` endpoint:

```bash
#!/bin/bash
set -euo pipefail

TAILSCALE_API_TOKEN=$(curl --retry 5 --retry-max-time 120 --silent \
                       -d "client_id=${TAILSCALE_CLIENT_ID}" \
                       -d "client_secret=${TAILSCALE_CLIENT_SECRET}" \
                       "https://api.tailscale.com/api/v2/oauth/token" \
                       | dasel -r json 'access_token' -w -)

# you could also just `jq -r '.access_token'` instead of dasel above

if [[ "${TAILSCALE_API_TOKEN}" == 'null' ]]
then
    >&2 echo 'ERROR: Tailscale API returned an invalid API token, aborting!'
    exit 1
fi

echo "${TAILSCALE_API_TOKEN}"
```