### PR TITLE
Allow tailnet to be rendered from a jinja2 template

### DIFF
--- a/plugins/inventory/tailscale.py
+++ b/plugins/inventory/tailscale.py
@@ -283,7 +283,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def get_inventory(self):
         api_key = self.templar.template(self.get_option("api_key"))
-        tailnet = self.get_option("tailnet")
+        tailnet = self.templar.template(self.get_option("tailnet"))
         tailscale = TailscaleAPI(
             api_key, tailnet, remove_tag_prefix=self.get_option("strip_tag")
         )


### PR DESCRIPTION
I would like to be able to programmatically set the tailnet name based on information external to ansible without having to update my tailscale inventory configuration.

This PR follows the pattern introduced in f35be58 and to make the tailnet configuration parameter rendered by jinja2 also.